### PR TITLE
Update README to use dark theme for profile images

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,13 @@
 </p>
 
 ---
+
 <h1 style="margin-top: 0px" align="center">
   
     ![](http://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=pronad1&theme=dark)
 
     ![](http://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=pronad1&theme=dark&utcOffset=6)
     ![](https://github-readme-stats.vercel.app/api/top-langs?username=pronad1&show_icons=true&locale=en&layout=compact&theme=dark)
-</h1>
-
-<h1 style="margin-top: 0px" align="center">
-  
-  ![](http://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=pronad1&theme=default)
-
-  ![](http://github-profile-summary-cards.vercel.app/api/cards/productive-time?username=pronad1&theme=default&utcOffset=6)
-  ![](https://github-readme-stats.vercel.app/api/top-langs?username=pronad1&show_icons=true&locale=en&layout=compact)
 
 
   <a href="https://github.com/pronad1/"><img src="https://komarev.com/ghpvc/?username=pronad1" alt="visitors" /></a>


### PR DESCRIPTION
Removed default theme images and kept dark theme images for GitHub profile summary cards.